### PR TITLE
fix: deduplicate Catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "stremio-core-web"
-version = "0.44.17"
+version = "0.44.18"
 dependencies = [
  "Inflector",
  "boolinator",

--- a/src/model/serialize_catalogs_with_extra.rs
+++ b/src/model/serialize_catalogs_with_extra.rs
@@ -1,5 +1,6 @@
 use crate::model::deep_links_ext::DeepLinksExt;
 use inflector::Inflector;
+use itertools::Itertools;
 use serde::Serialize;
 use stremio_core::deep_links::{DiscoverDeepLinks, MetaItemDeepLinks};
 use stremio_core::models::catalogs_with_extra::{CatalogsWithExtra, Selected};
@@ -9,6 +10,7 @@ use stremio_core::types::resource::PosterShape;
 use wasm_bindgen::JsValue;
 
 mod model {
+
     use super::*;
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -78,6 +80,7 @@ pub fn serialize_catalogs_with_extra(
                             Some(Loadable::Ready(
                                 meta_items
                                     .iter()
+                                    .unique_by(|meta_item| meta_item.id.clone())
                                     .take(10)
                                     .map(|meta_item| model::MetaItemPreview {
                                         meta_item,

--- a/src/model/serialize_catalogs_with_extra.rs
+++ b/src/model/serialize_catalogs_with_extra.rs
@@ -80,7 +80,7 @@ pub fn serialize_catalogs_with_extra(
                             Some(Loadable::Ready(
                                 meta_items
                                     .iter()
-                                    .unique_by(|meta_item| meta_item.id.clone())
+                                    .unique_by(|meta_item| &meta_item.id)
                                     .take(10)
                                     .map(|meta_item| model::MetaItemPreview {
                                         meta_item,

--- a/src/model/serialize_discover.rs
+++ b/src/model/serialize_discover.rs
@@ -1,6 +1,9 @@
-use crate::model::deep_links_ext::DeepLinksExt;
 use boolinator::Boolinator;
+use itertools::Itertools;
+
 use serde::Serialize;
+use wasm_bindgen::JsValue;
+
 use stremio_core::deep_links::{DiscoverDeepLinks, MetaItemDeepLinks, StreamDeepLinks};
 use stremio_core::models::catalog_with_filters::{
     CatalogWithFilters, Selected as CatalogWithFiltersSelected,
@@ -9,7 +12,8 @@ use stremio_core::models::common::Loadable;
 use stremio_core::models::ctx::Ctx;
 use stremio_core::models::streaming_server::StreamingServer;
 use stremio_core::types::resource::MetaItemPreview;
-use wasm_bindgen::JsValue;
+
+use crate::model::deep_links_ext::DeepLinksExt;
 
 mod model {
     use super::*;
@@ -200,6 +204,9 @@ pub fn serialize_discover(
                                     .into_web_deep_links(),
                                 })
                             })
+                            // it is possible that they are duplicates returned in 2 different pages
+                            // so we deduplicate all the results at once
+                            .unique_by(|meta| meta.meta_item.id.clone())
                             .collect::<Vec<_>>(),
                     ),
                     Some(Loadable::Loading) | None => Loadable::Loading,

--- a/src/model/serialize_discover.rs
+++ b/src/model/serialize_discover.rs
@@ -206,7 +206,7 @@ pub fn serialize_discover(
                             })
                             // it is possible that they are duplicates returned in 2 different pages
                             // so we deduplicate all the results at once
-                            .unique_by(|meta| meta.meta_item.id.clone())
+                            .unique_by(|meta| &meta.meta_item.id)
                             .collect::<Vec<_>>(),
                     ),
                     Some(Loadable::Loading) | None => Loadable::Loading,


### PR DESCRIPTION
- [x] fix Cargo.lock
- [x] deduplicate Discovery board - removes any MetaItems that are found to more than 1 page, keeping the order of the elements
- [x] deduplicate Catalogs with extra