### PR TITLE
Feat/LibraryItem deeplinks use StreamsBucket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 [[package]]
 name = "localsearch"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/local-search?branch=main#789d4d0a0fccb061fda4138a9520197446946b66"
+source = "git+https://github.com/Stremio/local-search?branch=main#74fefe1da2fa17d2b4ef7e3e629da00f3946ee72"
 dependencies = [
  "fst",
  "fxhash",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#4ddc8dcaa35fec84c8a0f089a85ffad0164c544a"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#65e08e59c4dd859c0f1e68b7ac86c5f0d98e1b09"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#4ddc8dcaa35fec84c8a0f089a85ffad0164c544a"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#65e08e59c4dd859c0f1e68b7ac86c5f0d98e1b09"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#4ddc8dcaa35fec84c8a0f089a85ffad0164c544a"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#65e08e59c4dd859c0f1e68b7ac86c5f0d98e1b09"
 dependencies = [
  "base64 0.13.1",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#65e08e59c4dd859c0f1e68b7ac86c5f0d98e1b09"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#bd2c7c82d876396e7f1465524a40c94f8d88e0a8"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#65e08e59c4dd859c0f1e68b7ac86c5f0d98e1b09"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#bd2c7c82d876396e7f1465524a40c94f8d88e0a8"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#65e08e59c4dd859c0f1e68b7ac86c5f0d98e1b09"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#bd2c7c82d876396e7f1465524a40c94f8d88e0a8"
 dependencies = [
  "base64 0.13.1",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#4380a6f53cb60037fd151c12226a2cd52547a482"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#d12b6892a3a664eebb7ba92521f90a1256feae4d"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#4380a6f53cb60037fd151c12226a2cd52547a482"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#d12b6892a3a664eebb7ba92521f90a1256feae4d"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#4380a6f53cb60037fd151c12226a2cd52547a482"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#d12b6892a3a664eebb7ba92521f90a1256feae4d"
 dependencies = [
  "base64 0.13.1",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#bd2c7c82d876396e7f1465524a40c94f8d88e0a8"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#4380a6f53cb60037fd151c12226a2cd52547a482"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#bd2c7c82d876396e7f1465524a40c94f8d88e0a8"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#4380a6f53cb60037fd151c12226a2cd52547a482"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#bd2c7c82d876396e7f1465524a40c94f8d88e0a8"
+source = "git+https://github.com/Stremio/stremio-core?branch=feat/continue-watching-item-stream#4380a6f53cb60037fd151c12226a2cd52547a482"
 dependencies = [
  "base64 0.13.1",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = true
 opt-level = 's'
 
 [dependencies]
-stremio-core = { git = "https://github.com/Stremio/stremio-core", features = ["derive", "analytics"], branch = "development" }
+stremio-core = { git = "https://github.com/Stremio/stremio-core", features = ["derive", "analytics"], branch = "feat/continue-watching-item-stream" }
 serde = { version = "1.0.*", features = ["derive"] }
 serde_json = "1.0.*"
 futures = "0.3.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = true
 opt-level = 's'
 
 [dependencies]
-stremio-core = { git = "https://github.com/Stremio/stremio-core", features = ["derive", "analytics"], branch = "feat/continue-watching-item-stream" }
+stremio-core = { git = "https://github.com/Stremio/stremio-core", features = ["derive", "analytics"], branch = "development" }
 serde = { version = "1.0.*", features = ["derive"] }
 serde_json = "1.0.*"
 futures = "0.3.*"

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -69,7 +69,7 @@ impl WebModel {
         notifications: NotificationsBucket,
     ) -> (WebModel, Effects) {
         let (continue_watching_preview, continue_watching_preview_effects) =
-            ContinueWatchingPreview::new(&library, &streams, &notifications);
+            ContinueWatchingPreview::new(&library, &notifications);
         let (discover, discover_effects) = CatalogWithFilters::<MetaItemPreview>::new(&profile);
         let (library_, library_effects) =
             LibraryWithFilters::<NotRemovedFilter>::new(&library, &notifications);
@@ -118,6 +118,7 @@ impl WebModel {
             WebModelField::DataExport => serialize_data_export(&self.data_export),
             WebModelField::ContinueWatchingPreview => serialize_continue_watching_preview(
                 &self.continue_watching_preview,
+                &self.ctx.streams,
                 self.streaming_server.base_url.ready(),
                 &self.ctx.profile.settings,
             ),

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -69,7 +69,7 @@ impl WebModel {
         notifications: NotificationsBucket,
     ) -> (WebModel, Effects) {
         let (continue_watching_preview, continue_watching_preview_effects) =
-            ContinueWatchingPreview::new(&library, &notifications);
+            ContinueWatchingPreview::new(&library, &streams, &notifications);
         let (discover, discover_effects) = CatalogWithFilters::<MetaItemPreview>::new(&profile);
         let (library_, library_effects) =
             LibraryWithFilters::<NotRemovedFilter>::new(&library, &notifications);
@@ -116,17 +116,29 @@ impl WebModel {
             WebModelField::Ctx => serialize_ctx(&self.ctx),
             WebModelField::AuthLink => JsValue::from_serde(&self.auth_link).unwrap(),
             WebModelField::DataExport => serialize_data_export(&self.data_export),
-            WebModelField::ContinueWatchingPreview => {
-                serialize_continue_watching_preview(&self.continue_watching_preview)
-            }
+            WebModelField::ContinueWatchingPreview => serialize_continue_watching_preview(
+                &self.continue_watching_preview,
+                self.streaming_server.base_url.ready(),
+                &self.ctx.profile.settings,
+            ),
             WebModelField::Board => serialize_catalogs_with_extra(&self.board, &self.ctx),
             WebModelField::Discover => {
                 serialize_discover(&self.discover, &self.ctx, &self.streaming_server)
             }
-            WebModelField::Library => serialize_library(&self.library, "library".to_owned()),
-            WebModelField::ContinueWatching => {
-                serialize_library(&self.continue_watching, "continuewatching".to_owned())
-            }
+            WebModelField::Library => serialize_library(
+                &self.library,
+                &self.ctx.streams,
+                self.streaming_server.base_url.ready(),
+                &self.ctx.profile.settings,
+                "library".to_owned(),
+            ),
+            WebModelField::ContinueWatching => serialize_library(
+                &self.continue_watching,
+                &self.ctx.streams,
+                self.streaming_server.base_url.ready(),
+                &self.ctx.profile.settings,
+                "continuewatching".to_owned(),
+            ),
             WebModelField::Search => serialize_catalogs_with_extra(&self.search, &self.ctx),
             WebModelField::LocalSearch => serialize_local_search(&self.local_search),
             WebModelField::MetaDetails => {

--- a/src/model/serialize_continue_watching_preview.rs
+++ b/src/model/serialize_continue_watching_preview.rs
@@ -29,8 +29,8 @@ mod model {
         deep_links::{LibraryDeepLinks, LibraryItemDeepLinks},
         types::{
             profile::Settings,
-            resource::{PosterShape, Stream},
-            streams::{StreamsBucket, StreamsItemKey},
+            resource::PosterShape,
+            streams::{StreamsBucket, StreamsItem, StreamsItemKey},
         },
     };
 
@@ -70,13 +70,10 @@ mod model {
                             .video_id
                             .clone()
                             .and_then(|video_id| {
-                                streams_bucket
-                                    .items
-                                    .get(&StreamsItemKey {
-                                        meta_id: core_cw_item.library_item.id.clone(),
-                                        video_id,
-                                    })
-                                    .map(|stream_item| &stream_item.stream)
+                                streams_bucket.items.get(&StreamsItemKey {
+                                    meta_id: core_cw_item.library_item.id.clone(),
+                                    video_id,
+                                })
                             });
 
                         Item::from((
@@ -105,15 +102,15 @@ mod model {
     impl<'a>
         From<(
             &'a stremio_core::models::continue_watching_preview::Item,
-            Option<&Stream>,
+            Option<&StreamsItem>,
             Option<&Url>,
             &Settings,
         )> for Item<'a>
     {
         fn from(
-            (item, stream, streaming_server_url, settings): (
+            (item, stream_item, streaming_server_url, settings): (
                 &'a stremio_core::models::continue_watching_preview::Item,
-                Option<&Stream>,
+                Option<&StreamsItem>,
                 Option<&Url>,
                 &Settings,
             ),
@@ -121,7 +118,7 @@ mod model {
             Self {
                 library_item: LibraryItem::from((
                     &item.library_item,
-                    stream,
+                    stream_item,
                     streaming_server_url,
                     settings,
                 )),
@@ -147,15 +144,15 @@ mod model {
     impl<'a>
         From<(
             &'a stremio_core::types::library::LibraryItem,
-            Option<&Stream>,
+            Option<&StreamsItem>,
             Option<&Url>,
             &Settings,
         )> for LibraryItem<'a>
     {
         fn from(
-            (library_item, stream, streaming_server_url, settings): (
+            (library_item, streams_item, streaming_server_url, settings): (
                 &'a stremio_core::types::library::LibraryItem,
-                Option<&Stream>,
+                Option<&StreamsItem>,
                 Option<&Url>,
                 &Settings,
             ),
@@ -178,7 +175,7 @@ mod model {
                 },
                 deep_links: LibraryItemDeepLinks::from((
                     library_item,
-                    stream,
+                    streams_item,
                     streaming_server_url,
                     settings,
                 ))

--- a/src/model/serialize_library.rs
+++ b/src/model/serialize_library.rs
@@ -108,17 +108,12 @@ pub fn serialize_library<F>(
             .map(|library_item| {
                 // Try to get the stream from the StreamBucket
                 // given that we have a video_id in the LibraryItemState!
-                let stream = library_item
-                    .state
-                    .video_id
-                    .as_ref()
-                    .and_then(|video_id| {
-                        streams_bucket.items.get(&StreamsItemKey {
-                            meta_id: library_item.id.to_owned(),
-                            video_id: video_id.to_owned(),
-                        })
+                let streams_item = library_item.state.video_id.as_ref().and_then(|video_id| {
+                    streams_bucket.items.get(&StreamsItemKey {
+                        meta_id: library_item.id.to_owned(),
+                        video_id: video_id.to_owned(),
                     })
-                    .map(|item| &item.stream);
+                });
 
                 model::LibraryItem {
                     id: &library_item.id,
@@ -139,7 +134,7 @@ pub fn serialize_library<F>(
                     },
                     deep_links: LibraryItemDeepLinks::from((
                         library_item,
-                        stream,
+                        streams_item,
                         streaming_server_url,
                         settings,
                     ))


### PR DESCRIPTION
- Core changes - https://github.com/Stremio/stremio-core/pull/522

For both Library and CW items the player link will lead you directly to the Stream inside the player.

### TODO
- [x] Revert core to `development` branch