### PR TITLE
feat: add dev build and skip package.json creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,19 @@ Bridge between [stremio-core](https://github.com/stremio/stremio-core) and [stre
 
 ## Build
 
-Builds a wasm package and prepares the rest of the dependencies for the npm package.
+Builds a production wasm package and prepares the rest of the dependencies for the npm package.
 
 ```
 npm install
 npm run build
+```
+
+### Development
+
+Building the package using [`./scripts/build.sh`](./scripts/build.sh) with `--dev` would allow you to see more logging messages being emitted, this is intended **only** for debugging as it will log messages with sensitive information!
+
+```
+./scripts/build.sh --dev
 ```
 
 ## Publishing

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -ex
-wasm-pack build --no-typescript --no-pack --out-dir wasm_build --release --target web
+MODE=${1:---release}
+wasm-pack build --no-typescript --no-pack --out-dir wasm_build $MODE --target web
 mv ./wasm_build/stremio_core_web_bg.wasm stremio_core_web_bg.wasm
 npx babel wasm_build/stremio_core_web.js --config-file ./.babelrc --out-file stremio_core_web.js
 npx babel src/bridge.js --config-file ./.babelrc --out-file bridge.js

--- a/scripts/dev-build.sh
+++ b/scripts/dev-build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -ex
-wasm-pack build --no-typescript --no-pack --out-dir wasm_build --release --target web
+wasm-pack build --no-typescript --no-pack --out-dir wasm_build --dev --target web
 mv ./wasm_build/stremio_core_web_bg.wasm stremio_core_web_bg.wasm
 npx babel wasm_build/stremio_core_web.js --config-file ./.babelrc --out-file stremio_core_web.js
 npx babel src/bridge.js --config-file ./.babelrc --out-file bridge.js

--- a/scripts/dev-build.sh
+++ b/scripts/dev-build.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -ex
-wasm-pack build --no-typescript --no-pack --out-dir wasm_build --dev --target web
-mv ./wasm_build/stremio_core_web_bg.wasm stremio_core_web_bg.wasm
-npx babel wasm_build/stremio_core_web.js --config-file ./.babelrc --out-file stremio_core_web.js
-npx babel src/bridge.js --config-file ./.babelrc --out-file bridge.js
-npx babel src/worker.js --config-file ./.babelrc --out-file worker.js


### PR DESCRIPTION
- `./scripts/dev-build.sh` can be used to build the wasm pack with `Trace` level of logging for debug purposes. Closes #46 
- Added `--no-pack` to wasm-pack command to skip the creation of the `package.json` file.