### PR TITLE
refactor!: return addon, id, name and type for catalogs

### DIFF
--- a/src/model/serialize_catalogs_with_extra.rs
+++ b/src/model/serialize_catalogs_with_extra.rs
@@ -14,8 +14,8 @@ mod model {
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ManifestPreview<'a> {
-        pub id: &'a String,
-        pub name: &'a String,
+        pub id: &'a str,
+        pub name: &'a str,
     }
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]

--- a/src/model/serialize_discover.rs
+++ b/src/model/serialize_discover.rs
@@ -20,6 +20,7 @@ mod model {
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ManifestPreview<'a> {
+        pub id: &'a String,
         pub name: &'a String,
     }
     #[derive(Serialize)]
@@ -46,6 +47,7 @@ mod model {
     pub struct SelectableCatalog<'a> {
         pub id: &'a String,
         pub name: &'a String,
+        pub r#type: &'a String,
         pub addon: DescriptorPreview<'a>,
         pub selected: &'a bool,
         pub deep_links: DiscoverDeepLinks,
@@ -133,8 +135,10 @@ pub fn serialize_discover(
                 .map(|(addon, selectable_catalog)| model::SelectableCatalog {
                     id: &selectable_catalog.request.path.id,
                     name: &selectable_catalog.catalog,
+                    r#type: &selectable_catalog.request.path.r#type,
                     addon: model::DescriptorPreview {
                         manifest: model::ManifestPreview {
+                            id: &addon.manifest.id,
                             name: &addon.manifest.name,
                         },
                     },

--- a/src/model/serialize_discover.rs
+++ b/src/model/serialize_discover.rs
@@ -47,7 +47,7 @@ mod model {
     pub struct SelectableCatalog<'a> {
         pub id: &'a String,
         pub name: &'a String,
-        pub r#type: &'a String,
+        pub r#type: &'a str,
         pub addon: DescriptorPreview<'a>,
         pub selected: &'a bool,
         pub deep_links: DiscoverDeepLinks,

--- a/src/model/serialize_discover.rs
+++ b/src/model/serialize_discover.rs
@@ -20,7 +20,7 @@ mod model {
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ManifestPreview<'a> {
-        pub id: &'a String,
+        pub id: &'a str,
         pub name: &'a String,
     }
     #[derive(Serialize)]


### PR DESCRIPTION
Related to 
https://github.com/Stremio/stremio-translations/pull/728
https://github.com/Stremio/stremio-web/pull/540

This is a breaking change, it will not return the `title` field for board catalogs anymore
So the catalog title should be created inside apps 