### PR TITLE
Use library item progress for continue watching preview

### DIFF
--- a/src/model/serialize_continue_watching_preview.rs
+++ b/src/model/serialize_continue_watching_preview.rs
@@ -169,11 +169,7 @@ mod model {
                     // else use the provided shape
                     _ => &library_item.poster_shape,
                 },
-                progress: if library_item.state.time_offset > 0 && library_item.state.duration > 0 {
-                    library_item.state.time_offset as f64 / library_item.state.duration as f64
-                } else {
-                    0.0
-                },
+                progress: library_item.progress(),
                 deep_links: LibraryItemDeepLinks::from((
                     library_item,
                     streams_item,


### PR DESCRIPTION
This caused discrepancies for the items progress, in this case it was not multiplied by 100