### PR TITLE
[Breaking] Fix upcoming state for videos

### DIFF
--- a/src/model/serialize_meta_details.rs
+++ b/src/model/serialize_meta_details.rs
@@ -50,7 +50,7 @@ mod model {
     pub struct Video<'a> {
         #[serde(flatten)]
         pub video: &'a stremio_core::types::resource::Video,
-        pub upcomming: bool,
+        pub upcoming: bool,
         pub watched: bool,
         // Watch progress percentage
         pub progress: Option<f64>,
@@ -150,12 +150,8 @@ pub fn serialize_meta_details(
                             .iter()
                             .map(|video| model::Video {
                                 video,
-                                upcomming: meta_item.preview.behavior_hints.has_scheduled_videos
-                                    && meta_item
-                                        .preview
-                                        .released
-                                        .map(|released| released > WebEnv::now())
-                                        .unwrap_or(true),
+                                upcoming: meta_item.preview.behavior_hints.has_scheduled_videos
+                                    && video.released > Some(WebEnv::now()),
                                 watched: meta_details
                                     .watched
                                     .as_ref()

--- a/src/model/serialize_player.rs
+++ b/src/model/serialize_player.rs
@@ -47,7 +47,7 @@ mod model {
     pub struct Video<'a> {
         #[serde(flatten)]
         pub video: &'a stremio_core::types::resource::Video,
-        pub upcomming: bool,
+        pub upcoming: bool,
         pub watched: bool,
         pub progress: Option<u32>,
         pub scheduled: bool,
@@ -137,12 +137,8 @@ pub fn serialize_player(player: &Player, ctx: &Ctx, streaming_server: &Streaming
                             .iter()
                             .map(|video| model::Video {
                                 video,
-                                upcomming: meta_item.preview.behavior_hints.has_scheduled_videos
-                                    && meta_item
-                                        .preview
-                                        .released
-                                        .map(|released| released > WebEnv::now())
-                                        .unwrap_or(true),
+                                upcoming: meta_item.preview.behavior_hints.has_scheduled_videos
+                                    && video.released > Some(WebEnv::now()),
                                 watched: false, // TODO use library
                                 progress: None, // TODO use library,
                                 scheduled: meta_item.preview.behavior_hints.has_scheduled_videos,
@@ -193,7 +189,7 @@ pub fn serialize_player(player: &Player, ctx: &Ctx, streaming_server: &Streaming
             .zip(player.next_video.as_ref())
             .map(|(request, video)| model::Video {
                 video,
-                upcomming: player
+                upcoming: player
                     .meta_item
                     .as_ref()
                     .and_then(|meta_item| match meta_item {
@@ -205,11 +201,7 @@ pub fn serialize_player(player: &Player, ctx: &Ctx, streaming_server: &Streaming
                     })
                     .map(|meta_item| {
                         meta_item.preview.behavior_hints.has_scheduled_videos
-                            && meta_item
-                                .preview
-                                .released
-                                .map(|released| released > WebEnv::now())
-                                .unwrap_or(true)
+                            && video.released > Some(WebEnv::now())
                     })
                     .unwrap_or_default(),
                 watched: false, // TODO use library


### PR DESCRIPTION
Was using the released date from the meta item instead of the video one, making it always false
Breaking change: rename `upcomming` to `upcoming`