### PR TITLE
Feat: Cargo feature to enable trace logging level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#768821a7057df1a7d49275e9c3cce15246b5bcbe"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#b81ebad287b6121a0b8b54ac164f09a941932187"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#768821a7057df1a7d49275e9c3cce15246b5bcbe"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#b81ebad287b6121a0b8b54ac164f09a941932187"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -1115,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#768821a7057df1a7d49275e9c3cce15246b5bcbe"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#b81ebad287b6121a0b8b54ac164f09a941932187"
 dependencies = [
  "base64 0.13.1",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ crate-type = ["cdylib"]
 lto = true
 opt-level = 's'
 
+[features]
+default = []
+# enable TRACE level of logging in the crate using `tracing`.
+log-trace = []
+
 [dependencies]
 stremio-core = { git = "https://github.com/Stremio/stremio-core", features = ["derive", "analytics"], branch = "development" }
 serde = { version = "1.0.*", features = ["derive"] }

--- a/src/stremio_core_web.rs
+++ b/src/stremio_core_web.rs
@@ -40,9 +40,9 @@ pub fn start() {
     // This is not needed for tracing_wasm to work, but it is a common tool for getting proper error line numbers for panics.
     console_error_panic_hook::set_once();
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature = "log-trace"))]
     let max_level = Level::TRACE;
-    #[cfg(not(debug_assertions))]
+    #[cfg(all(not(debug_assertions), not(feature = "log-trace")))]
     let max_level = Level::ERROR;
 
     let config = WASMLayerConfigBuilder::default()


### PR DESCRIPTION
This allows us to use the feature and enable TRACE logging without debug assertions (aka. dev. build) and going OOM when building the `core-asmjs` package for `stremio-theater`